### PR TITLE
Feat(report) : PDF 파일을 S3에 저장, 응답으로 S3 URL 반환

### DIFF
--- a/app/main_prod.py
+++ b/app/main_prod.py
@@ -104,12 +104,15 @@ def generate_json(req: ReportGenerationRequest = None):
         s3_client = boto3.client("s3")
         s3_client.upload_fileobj(pdf_buffer, s3_bucket, s3_key)
         
-        s3_url = f"https://{s3_bucket}.s3.amazonaws.com/{s3_key}"
+        region_name = s3_client.meta.region_name
+        s3_url = f"https://{s3_bucket}.s3.{region_name}.amazonaws.com/{s3_key}"
 
-        return JSONResponse({
+        response_data = {
             "url": s3_url,
             "createdAt": now.isoformat()
-        })
+        }
+
+        return JSONResponse(response_data)
     except Exception as e:
         logger.exception("generate_json FAILED")
         raise HTTPException(status_code=500, detail=f"Report generation failed: {str(e)}")

--- a/app/models.py
+++ b/app/models.py
@@ -45,5 +45,5 @@ class ReviewPayload(BaseModel):
 
 class GenerateJsonResponse(BaseModel):
     url: str
-    localPath: str
+    localPath: Optional[str] = None
     createdAt: str


### PR DESCRIPTION
생성한 PDF 파일이 S3에 저장되는 것을 확인했습니다.
응답으로는 해당 URL을 반환합니다.
Presigned URL을 발급하고 만료 시간을 설정하는 로직을 추가할 예정입니다.


아래 정보를 환경변수로 설정해야 합니다.

- AWS 자격 증명
AWS_ACCESS_KEY_ID=<YOUR_AWS_ACCESS_KEY_ID>
AWS_SECRET_ACCESS_KEY=<YOUR_AWS_SECRET_ACCESS_KEY>

-  PDF가 업로드될 S3 버킷 이름
OUTPUT_S3_BUCKET=<YOUR-S3-BUCKET-NAME>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * API 응답에서 localPath 필드가 선택 사항으로 변경되어, 필요 시 null 또는 미포함으로 반환됩니다.
* 버그 수정
  * S3 파일 URL이 리전별 엔드포인트를 사용하도록 개선되어 모든 리전에서 올바른 링크를 제공합니다.
* 리팩터
  * 응답 데이터 구성 로직을 정리했습니다. 응답 키(url, createdAt 등)와 오류 처리에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->