### PR TITLE
Refactor(report) : OpenAI, boto3 클라이언트 생성 시점 수정

### DIFF
--- a/app/main_prod.py
+++ b/app/main_prod.py
@@ -16,11 +16,14 @@ from .services.chart_analyzer import analyze_charts # 차트 분석
 from .services.pdf_generator import build_report_pdf  # PDF 생성
 from .services import plotter
 
-import boto3
 import logging
 logger = logging.getLogger("app")
 
 load_dotenv()
+
+# 재사용 가능한 객체는 핸들러 함수 바깥(모듈 레벨)에서 초기화 -> 성능 향상
+import boto3
+s3_client = boto3.client("s3")
 
 app = FastAPI(title="Report Server")
 
@@ -101,7 +104,6 @@ def generate_json(req: ReportGenerationRequest = None):
 
         # 4. 생성된 PDF를 S3에 업로드
         pdf_buffer.seek(0)
-        s3_client = boto3.client("s3")
         s3_client.upload_fileobj(pdf_buffer, s3_bucket, s3_key)
         
         region_name = s3_client.meta.region_name

--- a/app/services/chart_analyzer.py
+++ b/app/services/chart_analyzer.py
@@ -2,11 +2,10 @@ import os
 import io
 import base64
 from typing import Dict
-from openai import OpenAI
 from matplotlib.figure import Figure
 
-# OpenAI 클라이언트 초기화
-client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+# 공유 클라이언트를 임포트하여 사용
+from ..utils.openai_client import client
 
 def _figure_to_base64(fig: Figure) -> str:
     """Matplotlib Figure를 base64 인코딩된 PNG 문자열로 변환합니다."""

--- a/app/services/review_analyzer.py
+++ b/app/services/review_analyzer.py
@@ -4,14 +4,14 @@ from typing import List, Dict, Literal
 import numpy as np
 from dotenv import load_dotenv
 import traceback, sys
-
-from openai import OpenAI
 from sklearn.metrics.pairwise import cosine_similarity
 from scipy.sparse import csr_matrix
 from scipy.sparse.csgraph import connected_components
 import hdbscan
 
-from ..models import ReviewPayload, ReviewRow
+# 공유 클라이언트를 임포트하여 사용
+from ..utils.openai_client import client
+from ..models import ReviewPayload
 
 try:
     import kss
@@ -46,11 +46,6 @@ def _sentiment_of(sentence: str, rating: int) -> Literal["pos","neg","neu"]:
     if neg_hit > pos_hit: return "neg"
     return "neu"
 
-# === OpenAI ===
-load_dotenv()
-API_KEY = os.getenv('OPENAI_API_KEY')
-client = OpenAI(api_key = API_KEY)
-
 def _embed_sentences(sents: List[str]) -> np.ndarray:
     resp = client.embeddings.create(model="text-embedding-3-small", input=sents)
     vecs = np.array([d.embedding for d in resp.data], dtype="float32")
@@ -78,7 +73,7 @@ def _summarize_and_label_with_openai(sentences: List[str], label_hint: str = "")
     }
     prompt = (
         "다음 고객 리뷰 문장들을 근거로 결과를 생성하세요.\n"
-        "- label: 주제를 2~6자 내의 자연스러운 카테고리로 (예: 포장, 직원 응대, 배달 지연, 온도/식감, 가성비, 누락 등).\n"
+        "- label: 주제를 2~8자 내의 자연스러운 카테고리로 (예: 포장, 직원 응대, 배달 지연, 온도/식감, 가성비, 누락 등).\n"
         "- summary: 점주용 리포트에 들어갈 분석 요약. 1~2문장, 200자 이내.\n"
         "- 원문을 그대로 복사하지 말고, 의미를 유지하며 재서술할 것.\n"
         f"- 주제 힌트: {label_hint}\n"

--- a/app/utils/openai_client.py
+++ b/app/utils/openai_client.py
@@ -1,0 +1,8 @@
+from openai import OpenAI
+from .secrets import get_secret
+
+# 이 클라이언트는 모듈이 처음 임포트될 때 한 번만 초기화됩니다.
+# Lambda 웜 스타트 시에는 이 초기화 과정 없이 기존 클라이언트 객체가 재사용되어
+# Secrets Manager 호출을 방지하고 성능을 최적화합니다.
+# Secrets Manager에 {"OPENAI_API_KEY": "sk-..."} 형식으로 저장되어 있다고 가정합니다.
+client = OpenAI(api_key = get_secret("OPENAI_SECRET_NAME", "OPENAI_API_KEY"))


### PR DESCRIPTION
- boto3 클라이언트는 모듈 최상단에 초기화하여 모듈 레벨 재사용 가능하도록 변경
- SecretsManager에서 키 조회가 외부 의존이라서 지연 생성 (lazy) 하도록 변경